### PR TITLE
[Issue-39] adiciona rota de filtro de buscas

### DIFF
--- a/src/controllers/routeSearchesController.ts
+++ b/src/controllers/routeSearchesController.ts
@@ -19,4 +19,14 @@ export default class RouteSearchesController {
       return res.status(500).send({ message: 'Um erro inesperado aconteceu ao tentar salvar a rota buscada' });
     }
   }
+
+  public static async findBy(req: Request, res: Response): Promise<Response> {
+    try {
+      const routeSearches = await routeSearchDataSource.findBy(req.body);
+
+      res.status(200).json({ searches: routeSearches });
+    } catch (error) {
+      return res.status(500).send({ message: 'Um erro inesperado aconteceu ao buscar informações no banco' });
+    }
+  }
 }

--- a/src/database/db/routeSearch/postgresRouteSearchDataSource.ts
+++ b/src/database/db/routeSearch/postgresRouteSearchDataSource.ts
@@ -32,4 +32,32 @@ export class PostgresRouteSearchDataSource implements IRouteSearchDataSource {
 
     return rows[0];
   };
+
+  async findBy({ idCidadeOrigem, idCidadeDestino, idCid, dataInicio, dataFim }): Promise<RouteSearchDto[]> {
+    const baseQuery = ' SELECT * FROM searches s ';
+    const filters = [];
+
+    if (idCidadeOrigem) filters.push(`s.id_cidade_origem = ${idCidadeOrigem}`);
+    if (idCidadeDestino) filters.push(`s.id_cidade_destino = ${idCidadeDestino}`);
+    if (idCid) filters.push(`s.id_cid = ${idCid}`);
+    if (dataInicio) filters.push(`date(s.data_criacao) >= '${dataInicio}'`);
+    if (dataFim) filters.push(`date(s.data_criacao) <= '${dataFim}'`);
+
+    const whereClause = filters.length ? `WHERE ${filters.join(' AND ')}` : '';
+    const query = baseQuery + whereClause;
+
+    const { rows } = await this.dataBase.query(query);
+
+    return this.mapResultToModel(rows);
+  }
+
+  private mapResultToModel = (rows: any[]): RouteSearchDto[] => (
+    rows.map(row => ({
+      id: row.id,
+      idCidadeOrigem: row.id_cidade_origem,
+      idCidadeDestino: row.id_cidade_destino,
+      idCid: row.id_cid,
+      dataCriacao: row.data_criacao
+    }))
+  )
 }

--- a/src/dtos/routeSearchDto.ts
+++ b/src/dtos/routeSearchDto.ts
@@ -1,4 +1,5 @@
 export type RouteSearchDto = {
+  id?: number,
   idCidadeOrigem: number,
   idCidadeDestino: number,
   idCid?: number

--- a/src/routes/search.routes.ts
+++ b/src/routes/search.routes.ts
@@ -4,5 +4,6 @@ import routeSearchesController from './../controllers/routeSearchesController';
 const searchRoutes = Router();
 
 searchRoutes.post("/", routeSearchesController.create);
+searchRoutes.get("/", routeSearchesController.findBy);
 
 export { searchRoutes }

--- a/test/controllers/routeSearchesController.spec.ts
+++ b/test/controllers/routeSearchesController.spec.ts
@@ -9,6 +9,7 @@ const routeSearchRoutes = express();
 
 routeSearchRoutes.use(bodyParser.json());
 routeSearchRoutes.post('/', RouteSearchesController.create);
+routeSearchRoutes.get('/', RouteSearchesController.findBy);
 
 jest.mock('../../src/database/db/routeSearch/postgresRouteSearchDataSource');
 
@@ -60,6 +61,42 @@ describe('RouteSearchesController', () => {
       expect(response.status).toBe(201);
       expect(createMock).toHaveBeenCalledTimes(1);
       expect(response.body).toEqual({ message: 'Rota buscada salva com sucesso', routeSearch });
+    });
+  });
+
+  describe('findby', () => {
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should return 500 when query goes wrong', async () => {
+      const findByMock = jest.spyOn(PostgresRouteSearchDataSource.prototype, 'findBy');
+
+      findByMock.mockRejectedValueOnce(new Error('Message'));
+
+      const response = await request(routeSearchRoutes)
+        .get('/')
+        .send({})
+        .set('Content-type', 'application/json')
+
+      expect(findByMock).toHaveBeenCalledTimes(1);
+      expect(response.status).toBe(500);
+    });
+
+    it('should return 200 when query is successfully', async () => {
+      const routeSearches = [{ id: 99, idCidadeOrigem: 1, idCidadeDestino: 2, idCid: 3 }];
+      const findByMock = jest.spyOn(PostgresRouteSearchDataSource.prototype, 'findBy');
+
+      findByMock.mockResolvedValueOnce(routeSearches);
+
+      const response = await request(routeSearchRoutes)
+        .get('/')
+        .send({})
+        .set('Content-type', 'application/json')
+
+      expect(response.status).toBe(200);
+      expect(findByMock).toHaveBeenCalledTimes(1);
+      expect(response.body).toEqual({ searches: routeSearches });
     });
   });
 });

--- a/test/database/db/routeSearch/postgresRouteSearchDataSource.spec.ts
+++ b/test/database/db/routeSearch/postgresRouteSearchDataSource.spec.ts
@@ -58,4 +58,90 @@ describe('PostgresRouteSearchDataSource', () => {
       });
     });
   });
+
+  describe('findBy', () => {
+    const expectedRows = [{ id: 1 }];
+
+    it('should return all searches if no filters are provided', async () => {
+      const expectedQuery = ' SELECT * FROM searches s ';
+
+      mockPool.query.mockResolvedValueOnce({ rows: [expectedRows] } as never);
+      await dataSource.findBy({} as any);
+
+      expect(mockPool.query).toHaveBeenCalledWith(expectedQuery);
+    });
+
+    it('should return searches filtered by idCidadeOrigem', async () => {
+      const expectedQuery = ' SELECT * FROM searches s WHERE s.id_cidade_origem = 1';
+      const filters = { idCidadeOrigem: 1 };
+
+      mockPool.query.mockResolvedValueOnce({ rows: [expectedRows] } as never);
+      await dataSource.findBy(filters as any);
+
+      expect(mockPool.query).toHaveBeenCalledWith(expectedQuery);
+    });
+
+    it('should return searches filtered by idCidadeDestino', async () => {
+      const expectedQuery = ' SELECT * FROM searches s WHERE s.id_cidade_destino = 1';
+      const filters = { idCidadeDestino: 1 };
+
+      mockPool.query.mockResolvedValueOnce({ rows: [expectedRows] } as never);
+      await dataSource.findBy(filters as any);
+
+      expect(mockPool.query).toHaveBeenCalledWith(expectedQuery);
+    });
+
+    it('should return searches filtered by idCid', async () => {
+      const expectedQuery = ' SELECT * FROM searches s WHERE s.id_cid = 1';
+      const filters = { idCid: 1 };
+
+      mockPool.query.mockResolvedValueOnce({ rows: [expectedRows] } as never);
+      await dataSource.findBy(filters as any);
+
+      expect(mockPool.query).toHaveBeenCalledWith(expectedQuery);
+    });
+
+    it('should return searches filtered by dataInicio', async () => {
+      const expectedQuery = ' SELECT * FROM searches s WHERE date(s.data_criacao) >= \'2022-01-01\'';
+      const filters = { dataInicio: '2022-01-01' };
+
+      mockPool.query.mockResolvedValueOnce({ rows: [expectedRows] } as never);
+      await dataSource.findBy(filters as any);
+
+      expect(mockPool.query).toHaveBeenCalledWith(expectedQuery);
+    });
+
+    it('should return searches filtered by dataFim', async () => {
+      const expectedQuery = ' SELECT * FROM searches s WHERE date(s.data_criacao) <= \'2022-01-01\'';
+      const filters = { dataFim: '2022-01-01' };
+
+      mockPool.query.mockResolvedValueOnce({ rows: [expectedRows] } as never);
+      await dataSource.findBy(filters as any);
+
+      expect(mockPool.query).toHaveBeenCalledWith(expectedQuery);
+    });
+
+    it('should return searches filtered by all filters', async () => {
+      const expectedQuery =
+        ' SELECT * FROM searches s' +
+        ' WHERE s.id_cidade_origem = 1' +
+        ' AND s.id_cidade_destino = 2' +
+        ' AND s.id_cid = 3' +
+        ' AND date(s.data_criacao) >= \'2022-01-01\'' +
+        ' AND date(s.data_criacao) <= \'2022-01-02\'';
+
+      const filters = {
+        idCidadeOrigem: 1,
+        idCidadeDestino: 2,
+        idCid: 3,
+        dataInicio: '2022-01-01',
+        dataFim: '2022-01-02'
+      };
+
+      mockPool.query.mockResolvedValueOnce({ rows: [expectedRows] } as never);
+      await dataSource.findBy(filters as any);
+
+      expect(mockPool.query).toHaveBeenCalledWith(expectedQuery);
+    });
+  });
 });


### PR DESCRIPTION
Criar um endpoint para retornar as rotas buscadas salvas no banco - na busca podemos passar alguns filtros, como: `idCidadeOrigem`, `idCidadeDestino`, `dataInicio`, `dataFim` e `idCid` - caso nenhum parâmetro de filtro seja informado, retornamos todas as rotas buscadas.