### PR TITLE
[Issue 54] - Rota que retorna ranking de linhas buscadas

### DIFF
--- a/src/controllers/routeSearchesController.ts
+++ b/src/controllers/routeSearchesController.ts
@@ -11,9 +11,9 @@ export default class RouteSearchesController {
       const routeSearch = req.query as FindRouteSearchDto;
       RouteSearchesController.validateSearchParams(routeSearch);
 
-      const routeSearches = await routeSearchDataSource.get(routeSearch);
+      const data = await routeSearchDataSource.get(routeSearch);
 
-      res.status(200).send({ routeSearches });
+      res.status(200).send({ data });
     } catch (error) {
       console.log(error)
       if (error instanceof InvalidParamError) {
@@ -29,9 +29,9 @@ export default class RouteSearchesController {
       const rankingSearch = req.query as RankingSearchDto;
       RouteSearchesController.validateSearchParams(rankingSearch as FindRouteSearchDto);
 
-      const routeSearches = await routeSearchDataSource.getRanking(rankingSearch);
+      const data = await routeSearchDataSource.getRanking(rankingSearch);
 
-      res.status(200).send({ routeSearches });
+      res.status(200).send({ data });
     } catch (error) {
       console.log(error)
       if (error instanceof InvalidParamError) {

--- a/src/controllers/routeSearchesController.ts
+++ b/src/controllers/routeSearchesController.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import { PostgresRouteSearchDataSource } from "../database/db/routeSearch/postgresRouteSearchDataSource";
 import { InvalidParamError } from "../errors/invalidParamError";
-import { FindRouteSearchDto } from "../dtos/routeSearchDto";
+import { FindRouteSearchDto, RankingSearchDto } from "../dtos/routeSearchDto";
 
 const routeSearchDataSource = new PostgresRouteSearchDataSource();
 
@@ -21,6 +21,24 @@ export default class RouteSearchesController {
       }
 
       return res.status(500).send({ message: 'Um erro inesperado aconteceu ao encontrar as buscas realizadas' });
+    }
+  }
+
+  public static async getRanking(req: Request, res: Response): Promise<Response> {
+    try {
+      const rankingSearch = req.query as RankingSearchDto;
+      RouteSearchesController.validateSearchParams(rankingSearch as FindRouteSearchDto);
+
+      const routeSearches = await routeSearchDataSource.getRanking(rankingSearch);
+
+      res.status(200).send({ routeSearches });
+    } catch (error) {
+      console.log(error)
+      if (error instanceof InvalidParamError) {
+        return res.status(400).send({ message: error.message });
+      }
+
+      return res.status(500).send({ message: 'Um erro inesperado aconteceu ao obter o ranking das linhas' });
     }
   }
 

--- a/src/database/db/routeSearch/postgresRouteSearchDataSource.ts
+++ b/src/database/db/routeSearch/postgresRouteSearchDataSource.ts
@@ -1,5 +1,5 @@
 import { Pool } from "pg";
-import { RouteSearchDto, FindRouteSearchDto } from "../../../dtos/routeSearchDto";
+import { RouteSearchDto, FindRouteSearchDto, RankingSearchDto } from "../../../dtos/routeSearchDto";
 import { InvalidParamError } from "../../../errors/invalidParamError";
 import IRouteSearchDataSource from "../../interfaces/routeSearchDataSource";
 import PostgresDB from "../postgresDB";
@@ -70,6 +70,36 @@ export class PostgresRouteSearchDataSource implements IRouteSearchDataSource {
     const whereClause = queryFilters.join(' AND ');
 
     const query = `SELECT * FROM searches WHERE ${whereClause}`;
+
+    const { rows } = await this.dataBase.query(query);
+
+    return PostgresRouteSearchDataSource.mapResultToModel(rows);
+  };
+
+  async getRanking(params: RankingSearchDto): Promise<RouteSearchDto[]> {
+    const queryFilters: string[] = [];
+  
+    if (this.isParamFilled(params.sucedida)) {
+      queryFilters.push(`sucedida = '${params.sucedida}'`);
+    }
+
+    if (this.isParamFilled(params.idCid)) {
+      queryFilters.push(`id_cid = ${params.idCid}`);
+    }
+
+    if (this.isParamFilled(params.startDate)) {
+      queryFilters.push(`data_criacao::Date >= '${params.startDate}'::Date`);
+    }
+
+    if (this.isParamFilled(params.endDate)) {
+      queryFilters.push(`data_criacao::Date <= '${params.endDate}'::Date`);
+    }
+  
+    const whereClause = queryFilters.join(' AND ');
+    const limitFilter = this.isParamFilled(params.limite) ? 
+                        `LIMIT ${params.limite}` : "";
+
+    const query = `SELECT * FROM searches WHERE ${whereClause} ${limitFilter}`;
 
     const { rows } = await this.dataBase.query(query);
 

--- a/src/database/db/routeSearch/postgresRouteSearchDataSource.ts
+++ b/src/database/db/routeSearch/postgresRouteSearchDataSource.ts
@@ -103,7 +103,7 @@ export class PostgresRouteSearchDataSource implements IRouteSearchDataSource {
                   FROM searches 
                   WHERE ${whereClause} 
                   GROUP BY id_linha 
-                  ORDER BY count(*)
+                  ORDER BY count(*) desc
                   ${limitFilter}`;
 
     const { rows } = await this.dataBase.query(query);

--- a/src/dtos/routeSearchDto.ts
+++ b/src/dtos/routeSearchDto.ts
@@ -16,3 +16,11 @@ export type FindRouteSearchDto = {
   endDate?: string,
   line?: string
 };
+
+export type RankingSearchDto = {
+  sucedida?: boolean,
+  startDate?: string,
+  endDate?: string,
+  idCid?: number,
+  limite?: number
+};

--- a/src/dtos/routeSearchDto.ts
+++ b/src/dtos/routeSearchDto.ts
@@ -24,3 +24,8 @@ export type RankingSearchDto = {
   idCid?: number,
   limite?: number
 };
+
+export type RankingResultDto = {
+  idLinha: string,
+  searchCount: number
+};

--- a/src/routes/search.routes.ts
+++ b/src/routes/search.routes.ts
@@ -4,5 +4,6 @@ import routeSearchesController from './../controllers/routeSearchesController';
 const searchRoutes = Router();
 
 searchRoutes.get("/", routeSearchesController.get);
+searchRoutes.get("/ranking", routeSearchesController.getRanking);
 
 export { searchRoutes }

--- a/test/controllers/routeSearchesController.spec.ts
+++ b/test/controllers/routeSearchesController.spec.ts
@@ -3,7 +3,6 @@ import express from "express";
 import bodyParser from "body-parser";
 import RouteSearchesController from '../../src/controllers/routeSearchesController';
 import { PostgresRouteSearchDataSource } from '../../src/database/db/routeSearch/postgresRouteSearchDataSource';
-import { InvalidParamError } from '../../src/errors/invalidParamError';
 
 const routeSearchRoutes = express();
 
@@ -44,7 +43,7 @@ describe('RouteSearchesController', () => {
 
       expect(response.status).toBe(200);
       expect(createMock).toHaveBeenCalledTimes(1);
-      expect(response.body).toEqual({ routeSearches: result });
+      expect(response.body).toEqual({ data: result });
     });
 
     it('should return 400 when param is invalid', async () => {


### PR DESCRIPTION
**Rota**: `/searches/ranking`
**Parâmetros**: 

`sucedida`: boolean -> opcional
`startDate`: string  -> opcional
`endDate`: string  -> opcional
`idCid`: number  -> opcional,
`limite`: number  -> opcional

**OBS**: Apesar de todos serem opcionais, pelo menos `startDate` ou `endDate` devem ser informados, senão retorna erro 400.

Exemplo request: 
```http://localhost:3333/searches/ranking?startDate=09/17/2023&endDate&origin=77&destination&line=```

Exemplo resposta:

```json
{
    "data": [
        {
            "idLinha": null,
            "searchCount": "7"
        },
        {
            "idLinha": "082BI1",
            "searchCount": "1"
        },
        {
            "idLinha": "082DV1",
            "searchCount": "1"
        },
        {
            "idLinha": "082",
            "searchCount": "1"
        }
    ]
}
```

Pode ser que seja mesmo retornado `"idLinha": null` pois nem toda busca encontramos uma linha correspondente. 